### PR TITLE
fix: remove @semantic-release/git to fix release pipeline

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,15 +3,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     "@semantic-release/npm",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- Remove `@semantic-release/git` and `@semantic-release/changelog` plugins
- These plugins require pushing commits back to main, which is blocked by branch protection rulesets
- semantic-release uses git tags for version tracking, so this is safe
- Release notes go to GitHub Releases instead of CHANGELOG.md