### PR TITLE
fix: restore @semantic-release/git and use PAT for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -30,6 +31,6 @@ jobs:
       - run: pnpm build
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,15 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     "@semantic-release/npm",
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "package.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
+      }
+    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- Restore `@semantic-release/git` and `@semantic-release/changelog` plugins
- Use `GH_TOKEN` (PAT) instead of `GITHUB_TOKEN` for release step
- Add `persist-credentials: false` to checkout step

## Required
Add a `GH_TOKEN` secret with a Fine-grained PAT (Contents + Issues + PRs: Read & Write).